### PR TITLE
fix data races in tests

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -16,6 +16,7 @@ type Cache struct {
 	bucketMask  uint32
 	deletables  chan *Item
 	promotables chan *Item
+	donec       chan struct{}
 }
 
 // Create a new cache with the specified configuration
@@ -26,15 +27,13 @@ func New(config *Configuration) *Cache {
 		Configuration: config,
 		bucketMask:    uint32(config.buckets) - 1,
 		buckets:       make([]*bucket, config.buckets),
-		deletables:    make(chan *Item, config.deleteBuffer),
-		promotables:   make(chan *Item, config.promoteBuffer),
 	}
 	for i := 0; i < int(config.buckets); i++ {
 		c.buckets[i] = &bucket{
 			lookup: make(map[string]*Item),
 		}
 	}
-	go c.worker()
+	c.restart()
 	return c
 }
 
@@ -119,6 +118,14 @@ func (c *Cache) Clear() {
 // is called are likely to panic
 func (c *Cache) Stop() {
 	close(c.promotables)
+	<-c.donec
+}
+
+func (c *Cache) restart() {
+	c.deletables = make(chan *Item, c.deleteBuffer)
+	c.promotables = make(chan *Item, c.promoteBuffer)
+	c.donec = make(chan struct{})
+	go c.worker()
 }
 
 func (c *Cache) deleteItem(bucket *bucket, item *Item) {
@@ -146,6 +153,8 @@ func (c *Cache) promote(item *Item) {
 }
 
 func (c *Cache) worker() {
+	defer close(c.donec)
+
 	for {
 		select {
 		case item, ok := <-c.promotables:

--- a/secondarycache_test.go
+++ b/secondarycache_test.go
@@ -96,10 +96,10 @@ func (_ SecondaryCacheTests) TrackerDoesNotCleanupHeldInstance() {
 	sCache := cache.GetOrCreateSecondaryCache("0")
 	item := sCache.TrackingGet("a")
 	time.Sleep(time.Millisecond * 10)
-	cache.gc()
+	gcLayeredCache(cache)
 	Expect(cache.Get("0", "a").Value()).To.Equal(0)
 	Expect(cache.Get("1", "a")).To.Equal(nil)
 	item.Release()
-	cache.gc()
+	gcLayeredCache(cache)
 	Expect(cache.Get("0", "a")).To.Equal(nil)
 }


### PR DESCRIPTION
Fixes all data races when running `go test -race`.