### PR TITLE
Calling OnDelete from gc()

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,24 +2,28 @@
 
 
 [[projects]]
+  digest = "1:65c6a2822d8653e4f780c259a86d1b444c0b1ce7601b500deb985387bfe6bdec"
   name = "github.com/karlseguin/expect"
   packages = [
     ".",
     "build",
-    "mock"
+    "mock",
   ]
+  pruneopts = "UT"
   revision = "4fcda73748276dc72bcc09729bdb56242093c12c"
   version = "v1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:d594bb9f2a18ba4da7ab1368f4debf59f6b77cc7046705553f966837c12059f1"
   name = "github.com/wsxiaoys/terminal"
   packages = ["color"]
+  pruneopts = "UT"
   revision = "0940f3fc43a0ed42d04916b1c04578462c650b09"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a7bf38c5b0c419759438d9dca1af1ee50d70f07bc087f713c2ae35cbebdaf84b"
+  input-imports = ["github.com/karlseguin/expect"]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cache.go
+++ b/cache.go
@@ -223,6 +223,9 @@ func (c *Cache) gc() {
 			c.bucket(item.key).delete(item.key)
 			c.size -= item.size
 			c.list.Remove(element)
+			if c.onDelete != nil {
+				c.onDelete(item)
+			}
 			item.promotions = -2
 		}
 		element = prev

--- a/cache_test.go
+++ b/cache_test.go
@@ -98,7 +98,14 @@ func (_ CacheTests) TrackerDoesNotCleanupHeldInstance() {
 }
 
 func (_ CacheTests) RemovesOldestItemWhenFull() {
-	cache := New(Configure().MaxSize(5).ItemsToPrune(1))
+	onDeleteFnCalled := false
+	onDeleteFn := func(item *Item) {
+		if item.key == "0" {
+			onDeleteFnCalled = true
+		}
+	}
+
+	cache := New(Configure().MaxSize(5).ItemsToPrune(1).OnDelete(onDeleteFn))
 	for i := 0; i < 7; i++ {
 		cache.Set(strconv.Itoa(i), i, time.Minute)
 	}
@@ -106,6 +113,7 @@ func (_ CacheTests) RemovesOldestItemWhenFull() {
 	Expect(cache.Get("0")).To.Equal(nil)
 	Expect(cache.Get("1")).To.Equal(nil)
 	Expect(cache.Get("2").Value()).To.Equal(2)
+	Expect(onDeleteFnCalled).To.Equal(true)
 }
 
 func (_ CacheTests) RemovesOldestItemWhenFullBySizer() {

--- a/secondarycache_test.go
+++ b/secondarycache_test.go
@@ -2,9 +2,9 @@ package ccache
 
 import (
 	. "github.com/karlseguin/expect"
+	"strconv"
 	"testing"
 	"time"
-	"strconv"
 )
 
 type SecondaryCacheTests struct{}
@@ -77,14 +77,14 @@ func (_ SecondaryCacheTests) FetchReturnsAnExistingValue() {
 	cache := newLayered()
 	cache.Set("spice", "flow", "value-a", time.Minute)
 	sCache := cache.GetOrCreateSecondaryCache("spice")
-	val, _ := sCache.Fetch("flow", time.Minute, func() (interface{}, error) {return "a fetched value", nil})
+	val, _ := sCache.Fetch("flow", time.Minute, func() (interface{}, error) { return "a fetched value", nil })
 	Expect(val.Value().(string)).To.Equal("value-a")
 }
 
 func (_ SecondaryCacheTests) FetchReturnsANewValue() {
 	cache := newLayered()
 	sCache := cache.GetOrCreateSecondaryCache("spice")
-	val, _ := sCache.Fetch("flow", time.Minute, func() (interface{}, error) {return "a fetched value", nil})
+	val, _ := sCache.Fetch("flow", time.Minute, func() (interface{}, error) { return "a fetched value", nil })
 	Expect(val.Value().(string)).To.Equal("a fetched value")
 }
 


### PR DESCRIPTION
As per #21 previous implementation ignored `gc()` flow where `OnDelete` was not called when cache max-size is reached.

Also fixing some minor formatting problems.