### PR TITLE
new: option to prevent calling onDelete when doing set on existing item

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -143,7 +143,7 @@ func (c *Cache) deleteItem(bucket *bucket, item *Item) {
 
 func (c *Cache) set(key string, value interface{}, duration time.Duration) *Item {
 	item, existing := c.bucket(key).set(key, value, duration)
-	if existing != nil {
+	if existing != nil && !c.skipDeleteCallbackOnSet {
 		c.deletables <- existing
 	}
 	c.promote(item)

--- a/cache_test.go
+++ b/cache_test.go
@@ -49,6 +49,23 @@ func (_ CacheTests) OnDeleteCallbackCalled() {
 	Expect(onDeleteFnCalled).To.Equal(true)
 }
 
+func (_ CacheTests) OnDeleteCallbackSkipped() {
+	onDeleteFnCalled := false
+	onDeleteFn := func(item *Item) {
+		if item.key == "spice" {
+			onDeleteFnCalled = true
+		}
+	}
+
+	cache := New(Configure().OnDelete(onDeleteFn).SkipDeleteCallbackOnSet())
+	cache.Set("spice", "flow", time.Minute)
+	cache.Set("worm", "sand", time.Minute)
+
+	time.Sleep(time.Millisecond * 10) // Wait for worker to pick up deleted items
+
+	Expect(onDeleteFnCalled).To.Equal(false)
+}
+
 func (_ CacheTests) FetchesExpiredItems() {
 	cache := New(Configure())
 	fn := func() (interface{}, error) { return "moo-moo", nil }

--- a/configuration.go
+++ b/configuration.go
@@ -1,14 +1,15 @@
 package ccache
 
 type Configuration struct {
-	maxSize        int64
-	buckets        int
-	itemsToPrune   int
-	deleteBuffer   int
-	promoteBuffer  int
-	getsPerPromote int32
-	tracking       bool
-	onDelete       func(item *Item)
+	maxSize                 int64
+	buckets                 int
+	itemsToPrune            int
+	deleteBuffer            int
+	promoteBuffer           int
+	getsPerPromote          int32
+	tracking                bool
+	onDelete                func(item *Item)
+	skipDeleteCallbackOnSet bool
 }
 
 // Creates a configuration object with sensible defaults
@@ -16,13 +17,14 @@ type Configuration struct {
 // e.g.: ccache.New(ccache.Configure().MaxSize(10000))
 func Configure() *Configuration {
 	return &Configuration{
-		buckets:        16,
-		itemsToPrune:   500,
-		deleteBuffer:   1024,
-		getsPerPromote: 3,
-		promoteBuffer:  1024,
-		maxSize:        5000,
-		tracking:       false,
+		buckets:                 16,
+		itemsToPrune:            500,
+		deleteBuffer:            1024,
+		getsPerPromote:          3,
+		promoteBuffer:           1024,
+		maxSize:                 5000,
+		tracking:                false,
+		skipDeleteCallbackOnSet: false,
 	}
 }
 
@@ -99,5 +101,12 @@ func (c *Configuration) Track() *Configuration {
 // cached object that require some kind of tear-down.
 func (c *Configuration) OnDelete(callback func(item *Item)) *Configuration {
 	c.onDelete = callback
+	return c
+}
+
+// SkipDeleteCallbackOnSet prevents calling onDelete callback when overwritting
+// an exiting item using Set or Replace.
+func (c *Configuration) SkipDeleteCallbackOnSet() *Configuration {
+	c.skipDeleteCallbackOnSet = true
 	return c
 }

--- a/event.go
+++ b/event.go
@@ -1,0 +1,13 @@
+package ccache
+
+type eventKind int32
+
+const (
+	eventKindDelete eventKind = iota
+	eventKindUpdate
+)
+
+type event struct {
+	item *Item
+	kind eventKind
+}

--- a/layeredbucket.go
+++ b/layeredbucket.go
@@ -61,7 +61,7 @@ func (b *layeredBucket) delete(primary, secondary string) *Item {
 	return bucket.delete(secondary)
 }
 
-func (b *layeredBucket) deleteAll(primary string, deletables chan *Item) bool {
+func (b *layeredBucket) deleteAll(primary string, deletables chan event) bool {
 	b.RLock()
 	bucket, exists := b.buckets[primary]
 	b.RUnlock()
@@ -77,7 +77,7 @@ func (b *layeredBucket) deleteAll(primary string, deletables chan *Item) bool {
 	}
 	for key, item := range bucket.lookup {
 		delete(bucket.lookup, key)
-		deletables <- item
+		deletables <- event{item, eventKindDelete}
 	}
 	return true
 }

--- a/layeredcache.go
+++ b/layeredcache.go
@@ -170,7 +170,7 @@ func (c *LayeredCache) restart() {
 
 func (c *LayeredCache) set(primary, secondary string, value interface{}, duration time.Duration) *Item {
 	item, existing := c.bucket(primary).set(primary, secondary, value, duration)
-	if existing != nil {
+	if existing != nil && !c.skipDeleteCallbackOnSet {
 		c.deletables <- existing
 	}
 	c.promote(item)

--- a/layeredcache_test.go
+++ b/layeredcache_test.go
@@ -98,6 +98,24 @@ func (_ *LayeredCacheTests) OnDeleteCallbackCalled() {
 	Expect(onDeleteFnCalled).To.Equal(true)
 }
 
+func (_ *LayeredCacheTests) OnDeleteCallbackSkipped() {
+	onDeleteFnCalled := false
+	onDeleteFn := func(item *Item) {
+		if item.key == "spice" {
+			onDeleteFnCalled = true
+		}
+	}
+
+	cache := Layered(Configure().OnDelete(onDeleteFn).SkipDeleteCallbackOnSet())
+	cache.Set("spice", "flow", "value-a", time.Minute)
+	cache.Set("spice", "must", "value-b", time.Minute)
+	cache.Set("leto", "sister", "ghanima", time.Minute)
+
+	time.Sleep(time.Millisecond * 10) // Wait for worker to pick up deleted items
+
+	Expect(onDeleteFnCalled).To.Equal(false)
+}
+
 func (_ *LayeredCacheTests) DeletesALayer() {
 	cache := newLayered()
 	cache.Set("spice", "flow", "value-a", time.Minute)

--- a/secondarycache.go
+++ b/secondarycache.go
@@ -18,7 +18,7 @@ func (s *SecondaryCache) Get(secondary string) *Item {
 func (s *SecondaryCache) Set(secondary string, value interface{}, duration time.Duration) *Item {
 	item, existing := s.bucket.set(secondary, value, duration)
 	if existing != nil {
-		s.pCache.deletables <- existing
+		s.pCache.deletables <- event{existing, eventKindUpdate}
 	}
 	s.pCache.promote(item)
 	return item
@@ -43,7 +43,7 @@ func (s *SecondaryCache) Fetch(secondary string, duration time.Duration, fetch f
 func (s *SecondaryCache) Delete(secondary string) bool {
 	item := s.bucket.delete(secondary)
 	if item != nil {
-		s.pCache.deletables <- item
+		s.pCache.deletables <- event{item, eventKindDelete}
 		return true
 	}
 	return false


### PR DESCRIPTION
This patch adds the option `SkipDeleteCallbackOnSet` that will prevent the cache for calling the `onDelete` callback when calling `Set` on an existing key.