### PR TITLE
fixed/module: expect needs to be on master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/karlseguin/ccache
 go 1.13
 
 require (
-	github.com/karlseguin/expect v1.0.1
+	github.com/karlseguin/expect v1.0.2-0.20190806010014-778a5f0c6003
 	github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/karlseguin/expect v1.0.1 h1:z4wy4npwwHSWKjGWH85WNJO42VQhovxTCZDSzhjo8hY=
 github.com/karlseguin/expect v1.0.1/go.mod h1:zNBxMY8P21owkeogJELCLeHIt+voOSduHYTFUbwRAV8=
+github.com/karlseguin/expect v1.0.2-0.20190806010014-778a5f0c6003 h1:vJ0Snvo+SLMY72r5J4sEfkuE7AFbixEP2qRbEcum/wA=
+github.com/karlseguin/expect v1.0.2-0.20190806010014-778a5f0c6003/go.mod h1:zNBxMY8P21owkeogJELCLeHIt+voOSduHYTFUbwRAV8=
 github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0 h1:3UeQBvD0TFrlVjOeLOBz+CPAI8dnbqNSVwUwRrkp7vQ=
 github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0/go.mod h1:IXCdmsXIht47RaVFLEdVnh1t+pgYtTAhQGj73kz+2DM=


### PR DESCRIPTION
It seems github.com/karlseguin/expect@v1.0.1 tests are broken with go.1.13 unless we point to latest master