### PR TITLE
Fix race condition in Cache.Get()

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -85,7 +85,7 @@ func (c *Cache) Get(key string) *Item {
 	if item == nil {
 		return nil
 	}
-	if item.expires > time.Now().UnixNano() {
+	if !item.Expired() {
 		c.promote(item)
 	}
 	return item


### PR DESCRIPTION
Cache.Get() accesses the expires field in the Item without any sort of locking
or atomicity. This is an issue because Item.Extend() can be called from a
separate thread and cause a race condition.

```
WARNING: DATA RACE
Write at 0x00c000190028 by goroutine 12:
  sync/atomic.StoreInt64()
      /usr/local/Cellar/go/1.14/libexec/src/runtime/race_amd64.s:234 +0xb
  github.com/karlseguin/ccache.(*Item).Extend()

Previous read at 0x00c000190028 by goroutine 10:
  github.com/karlseguin/ccache.(*Cache).Get()
```