### PR TITLE
Avoid blocking if promotables channel is full.

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -206,7 +206,11 @@ func (c *Cache) bucket(key string) *bucket {
 }
 
 func (c *Cache) promote(item *Item) {
-	c.promotables <- item
+	select {
+	case c.promotables <- item:
+	default:
+	}
+		
 }
 
 func (c *Cache) worker() {


### PR DESCRIPTION
In rare situation it is possible to have `promotables` channel full. In such condition, the `Get` function will be blocked because it calls `promote` function. `Get` function being blocked defeats the purpose of fast cache response and hence may impact the application code in unexpected manner.
In this commit, the `promote` function is modified to use non-blocking channel send construct.