### PR TITLE
Fix memory leak on cleanup

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -100,6 +100,9 @@ func (b *bucket[T]) deletePrefix(prefix string, deletables chan *Item[T]) int {
 
 func (b *bucket[T]) clear() {
 	b.Lock()
+	for _, item := range b.lookup {
+		item.node = nil
+	}
 	b.lookup = make(map[string]*Item[T])
 	b.Unlock()
 }


### PR DESCRIPTION
We found a memory leak when cache cleans up in our service. I also tried to recreate cache instead of using 'Clean()', but in that case memory leaks too. I found out that the even if cache is deleted, cache items still remain in memry. With each 'Clean()' call, memory overhead grew. I also tracked the number of items using 'runtime.Finalizer' and it also grew. 
This fix solved this issue for me.

Also I think there is a problem here
https://github.com/karlseguin/ccache/blob/master/cache.go#L238 .
We must clear the buckets and the list atomically. Otherwise, we can add new items in parallel and then they will have time to be added to the buckets, but immediately removed from the list and we cannot clear them until the next clearing.
