### PR TITLE
Added Key() method to Item

### DIFF
--- a/item.go
+++ b/item.go
@@ -55,6 +55,10 @@ func (i *Item[T]) shouldPromote(getsPerPromote int32) bool {
 	return i.promotions == getsPerPromote
 }
 
+func (i *Item[T]) Key() string {
+	return i.key
+}
+
 func (i *Item[T]) Value() T {
 	return i.value
 }

--- a/item_test.go
+++ b/item_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/karlseguin/ccache/v3/assert"
 )
 
+func Test_Item_Key(t *testing.T) {
+	item := &Item[int]{key: "foo"}
+	assert.Equal(t, item.Key(), "foo")
+}
+
 func Test_Item_Promotability(t *testing.T) {
 	item := &Item[int]{promotions: 4}
 	assert.Equal(t, item.shouldPromote(5), true)


### PR DESCRIPTION
I need it in order to use check it OnDelete.
Example:  
```
ccache.New(
	ccache.Configure().MaxSize(1000).OnDelete(
		func(item *ccache.Item) {
			if util.IsFileCacheKey(item.Key()) {
				if err := os.Remove(item.Value().(string)); err != nil {
					logger.Error("Can't remove file", zap.Error(err), zap.String("file", item.Value().(string)))
				}
			}
		},
	),
)
```