### PR TITLE
perf: add setnx2

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -59,6 +59,30 @@ func (b *bucket[T]) setnx(key string, value T, duration time.Duration, track boo
 	return newItem
 }
 
+func (b *bucket[T]) setnx2(key string, f func() T, duration time.Duration, track bool) *Item[T] {
+	b.RLock()
+	item := b.lookup[key]
+	b.RUnlock()
+	if item != nil {
+		return item
+	}
+
+	b.Lock()
+	defer b.Unlock()
+
+	// check again under write lock
+	item = b.lookup[key]
+	if item != nil {
+		return item
+	}
+
+	expires := time.Now().Add(duration).UnixNano()
+	newItem := newItem(key, f(), expires, track)
+
+	b.lookup[key] = newItem
+	return newItem
+}
+
 func (b *bucket[T]) set(key string, value T, duration time.Duration, track bool) (*Item[T], *Item[T]) {
 	expires := time.Now().Add(duration).UnixNano()
 	item := newItem(key, value, expires, track)

--- a/bucket.go
+++ b/bucket.go
@@ -59,12 +59,12 @@ func (b *bucket[T]) setnx(key string, value T, duration time.Duration, track boo
 	return newItem
 }
 
-func (b *bucket[T]) setnx2(key string, f func() T, duration time.Duration, track bool) *Item[T] {
+func (b *bucket[T]) setnx2(key string, f func() T, duration time.Duration, track bool) (*Item[T], bool) {
 	b.RLock()
 	item := b.lookup[key]
 	b.RUnlock()
 	if item != nil {
-		return item
+		return item, true
 	}
 
 	b.Lock()
@@ -73,14 +73,14 @@ func (b *bucket[T]) setnx2(key string, f func() T, duration time.Duration, track
 	// check again under write lock
 	item = b.lookup[key]
 	if item != nil {
-		return item
+		return item, true
 	}
 
 	expires := time.Now().Add(duration).UnixNano()
 	newItem := newItem(key, f(), expires, track)
 
 	b.lookup[key] = newItem
-	return newItem
+	return newItem, false
 }
 
 func (b *bucket[T]) set(key string, value T, duration time.Duration, track bool) (*Item[T], *Item[T]) {

--- a/cache.go
+++ b/cache.go
@@ -124,6 +124,11 @@ func (c *Cache[T]) Setnx(key string, value T, duration time.Duration) {
 	c.bucket(key).setnx(key, value, duration, false)
 }
 
+// Setnx2 set the value in the cache for the specified duration if not exists
+func (c *Cache[T]) Setnx2(key string, f func() T, duration time.Duration) *Item[T] {
+	return c.bucket(key).setnx2(key, f, duration, false)
+}
+
 // Replace the value if it exists, does not set if it doesn't.
 // Returns true if the item existed an was replaced, false otherwise.
 // Replace does not reset item's TTL

--- a/cache.go
+++ b/cache.go
@@ -126,7 +126,9 @@ func (c *Cache[T]) Setnx(key string, value T, duration time.Duration) {
 
 // Setnx2 set the value in the cache for the specified duration if not exists
 func (c *Cache[T]) Setnx2(key string, f func() T, duration time.Duration) *Item[T] {
-	return c.bucket(key).setnx2(key, f, duration, false)
+	item := c.bucket(key).setnx2(key, f, duration, false)
+	c.promotables <- item
+	return item
 }
 
 // Replace the value if it exists, does not set if it doesn't.


### PR DESCRIPTION
1. add setnx2 to bucket, the differents from setnx are:
- init newItem after double check
- use func instead of value to reduce init cost of value
- return existing
2. add setnx2 to cache, the differents from setnx are:
- return *Item[T]
- handle promotables