### PR TITLE
Fix single-item cache bug

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -331,7 +331,7 @@ doAllDeletes:
 }
 
 func (c *Cache[T]) doDelete(item *Item[T]) {
-	if item.next == nil && item.prev == nil {
+	if !item.inList {
 		item.promotions = -2
 	} else {
 		c.size -= item.size
@@ -344,12 +344,12 @@ func (c *Cache[T]) doDelete(item *Item[T]) {
 }
 
 func (c *Cache[T]) doPromote(item *Item[T]) bool {
-	//already deleted
+	// already deleted
 	if item.promotions == -2 {
 		return false
 	}
 
-	if item.next != nil || item.prev != nil { // not a new item
+	if item.inList {
 		if item.shouldPromote(c.getsPerPromote) {
 			c.list.MoveToFront(item)
 			item.promotions = 0

--- a/item.go
+++ b/item.go
@@ -29,6 +29,7 @@ type Item[T any] struct {
 	value      T
 	next       *Item[T]
 	prev       *Item[T]
+	inList     bool
 }
 
 func newItem[T any](key string, value T, expires int64, track bool) *Item[T] {

--- a/layeredcache.go
+++ b/layeredcache.go
@@ -293,7 +293,7 @@ drain:
 }
 
 func (c *LayeredCache[T]) doDelete(item *Item[T]) {
-	if item.prev == nil && item.next == nil {
+	if !item.inList {
 		item.promotions = -2
 	} else {
 		c.size -= item.size
@@ -311,7 +311,7 @@ func (c *LayeredCache[T]) doPromote(item *Item[T]) bool {
 		return false
 	}
 
-	if item.next != nil || item.prev != nil { // not a new item
+	if item.inList {
 		if item.shouldPromote(c.getsPerPromote) {
 			c.list.MoveToFront(item)
 			item.promotions = 0

--- a/list.go
+++ b/list.go
@@ -26,6 +26,7 @@ func (l *List[T]) Remove(item *Item[T]) {
 	}
 	item.next = nil
 	item.prev = nil
+	item.inList = false
 }
 
 func (l *List[T]) MoveToFront(item *Item[T]) {
@@ -36,6 +37,7 @@ func (l *List[T]) MoveToFront(item *Item[T]) {
 func (l *List[T]) Insert(item *Item[T]) {
 	head := l.Head
 	l.Head = item
+	item.inList = true
 	if head == nil {
 		l.Tail = item
 		return


### PR DESCRIPTION
Fixes a bug introduced in v3.0.7 where the first/only item in the cache is incorrectly handled during promotion and deletion.

## Bug

The v3.0.7 release changed from external `Node` pointers to intrinsic linked list pointers (`next`/`prev` embedded in `Item`). 
The code uses `next == nil && prev == nil` to detect if an item is not in the list.

However, when inserting into an empty list, `Insert()` returns early without setting `next` or `prev`, leaving both as `nil`. This means the first/only item in the cache has both pointers `nil` while legitimately being in the list.

This causes two bugs:

1. **Promotion** (`doPromote`): A single item is incorrectly treated as "new", causing `size` to be incremented again
2. **Deletion** (`doDelete`): The cleanup path is skipped entirely, `size` is not decremented and `onDelete` callback is never called.

## Changes

- Add an explicit `inList` boolean field to `Item`
- Set `inList` to `true` in `Insert()` and `false` in `Remove()`.
- Replace all `next`/`prev` nil checks with `inList` in both `Cache` and `LayeredCache`.

## Performance

The inList boolean adds a small memory overhead (~1-8 bytes per item including padding). 
On amd64 the Item struct already uses 2 cache-lines, the new field does not change that.

Negligible CPU cost reduction: from two pointer comparisons to a single boolean check. 